### PR TITLE
Add dirent.c to sources in this Makefile as well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRCS=		luaunix.c pwd.c select.c
+SRCS=		luaunix.c pwd.c select.c dirent.c
 LIB=		unix
 
 OS!=		uname


### PR DESCRIPTION
~/luaunix/obj$ lua53 -lunix
lua53:./unix.so: undefined symbol 'unix_opendir'
lua53:./unix.so: undefined symbol 'unix_seekdir'
lua53:./unix.so: undefined symbol 'unix_closedir'
lua53:./unix.so: undefined symbol 'unix_readdir'
lua53:./unix.so: undefined symbol 'unix_rewinddir'
lua53:./unix.so: undefined symbol 'unix_telldir'
lua53: error loading module 'unix' from file './unix.so':
        Cannot load specified object
stack traceback:
        [C]: in ?
        [C]: in function 'require'
        [C]: in ?
