### PR TITLE
Don't leak a file descriptor if lua_newuserdata() fails.

### DIFF
--- a/dirent.c
+++ b/dirent.c
@@ -36,17 +36,15 @@
 int
 unix_opendir(lua_State *L)
 {
-	DIR *dirp;
 	DIR **dirpp;
+	const char *dir = luaL_checkstring(L, 1);
 
-	dirp = opendir(luaL_checkstring(L, 1));
-	if (dirp == NULL)
+	dirpp = lua_newuserdata(L, sizeof(DIR *));
+	*dirpp = opendir(dir);
+	if (*dirpp == NULL)
 		lua_pushnil(L);
-	else {
-		dirpp = lua_newuserdata(L, sizeof(DIR **));
-		*dirpp = dirp;
+	else
 		luaL_setmetatable(L, DIR_METATABLE);
-	}
 	return 1;
 }
 

--- a/luaunix.c
+++ b/luaunix.c
@@ -113,9 +113,8 @@ unix_kill(lua_State *L)
 static int
 unix_getcwd(lua_State *L)
 {
-	char *cwd;
+	char cwd[PATH_MAX];
 
-	cwd = alloca(PATH_MAX);
 	if (getcwd(cwd, PATH_MAX) != NULL)
 		lua_pushstring(L, cwd);
 	else


### PR DESCRIPTION
Also, we allocate DIR * userdata, not DIR **.